### PR TITLE
添加PopClip 插件版本，方便直接划词查询

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ https://lab.magiconch.com/nbnhhsh/
 [新 话 词 典](https://www.icloud.com/shortcuts/4e92f17ef2fb42b093457978624f275b)
 一个简易的隐私向 iOS 快捷指令，在本地抹除选中内容的主要文字后仅查询/提交包含的拼音数字缩写
 
+[PopClip 插件](https://github.com/qazhuhuihao/nbnhhsh.popclipext) @hhh
+
 ## GreasyFork
 [https://greasyfork.org/zh-CN/scripts/398555](https://greasyfork.org/zh-CN/scripts/398555)
 


### PR DESCRIPTION
能不能好好说话？的PopClip 插件版本，能在macos大多数位置直接划词查询，源码见：https://github.com/qazhuhuihao/nbnhhsh.popclipext