### PR TITLE
Remove redundant match addresses

### DIFF
--- a/nbnhhsh.user.js
+++ b/nbnhhsh.user.js
@@ -4,14 +4,11 @@
 // @version      0.14
 // @description  首字母缩写划词翻译工具
 // @author       itorr
-// @match        *://weibo.com/*
 // @match        *://*.weibo.com/*
 // @match        *://*.weibo.cn/*
 // @match        *://tieba.baidu.com/*
-// @match        *://*.bilibili.com/
 // @match        *://*.bilibili.com/*
 // @match        *://*.douban.com/group/*
-// @match        *://douban.com/group/*
 // @require      https://cdn.bootcss.com/vue/2.6.11/vue.min.js
 // @grant        none
 // ==/UserScript==


### PR DESCRIPTION
Removed redundant match addresses.
General match address just need to be `*://*.host.main.domain/*`.

See [Chrome](https://developer.chrome.com/docs/extensions/mv3/match_patterns/) and [Mozilla](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns) documentation, preceding `*.` in host matches the **given host** and any of its subdomains, and `*` in path matches **0** or more characters.